### PR TITLE
Remove dead link of boringdroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # AG-EMU 
-(forked from https://github.com/boringdroid/bdtools)
-
-The `agemu` is used to build portable emulator system images, and let user can run ag with emulator in Android Stduio. It also help `BoringdroidSystemUI` developer to develop `BoringdroidSystemUI` without downloading full source code.
+The `agemu` is used to build portable emulator system images, and let user can run ag with emulator in Android Studio.
 
 ## package ag 11
 


### PR DESCRIPTION
The `bdtools` was deleted, and new method is moving to `device/generic/boringdroid_x86_64`.